### PR TITLE
jq image improvements

### DIFF
--- a/src/jq/Dockerfile
+++ b/src/jq/Dockerfile
@@ -1,16 +1,9 @@
-FROM busybox:glibc as base
-
-# -- download
-FROM curlimages/curl as download
+FROM busybox:glibc
 
 ARG RELEASE=1.6
 
-RUN curl -L "https://github.com/stedolan/jq/releases/download/jq-$RELEASE/jq-linux64" -o /tmp/jq
-
-# -- production
-FROM base as production
-
-COPY --from=download /tmp/jq /usr/local/bin/jq
+RUN mkdir -p /usr/local/bin && \
+    wget "https://github.com/stedolan/jq/releases/download/jq-$RELEASE/jq-linux64" -O /usr/local/bin/jq
 
 RUN chmod +x /usr/local/bin/jq
 

--- a/src/jq/Dockerfile
+++ b/src/jq/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox as base
+FROM busybox:glibc as base
 
 # -- download
 FROM curlimages/curl as download


### PR DESCRIPTION
## Purpose

After discussion with the @openfun team, the `jq` image needed a small revamp.

## Proposal

- [x] use `busybox:glibc` as base image
- [x] remove the download step
